### PR TITLE
添加一个开关控制弱加载区块的怪物 despawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,15 @@ Enables `/raid` command for raid tracking
 - Categories: `TIS`, `COMMAND`
 
 
+## keepMobInLazyChunks
+
+The mobs in lazy chunks will not despawn, like the behavior before 1.15
+
+- Type: `boolean`  
+- Default value: `false`  
+- Suggested options: `false`, `true`
+- Categories: `FEATURE`, `EXPERIMENTAL` 
+
 
 -----------
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -190,6 +190,16 @@ CurseForge 主页[传送门](https://www.curseforge.com/minecraft/mc-mods/carpet
 - 参考选项: `false`, `true`
 - 分类: `TIS`, `COMMAND`
 
+
+## 保持弱加载区块的怪物 (keepMobInLazyChunks)
+
+弱加载区块的怪物不再会被刷新掉，就像 1.15 之前版本似的
+
+- 类型: `boolean`  
+- 默认值: `false`  
+- 参考选项: `false`, `true`
+- 分类: `FEATURE`, `EXPERIMENTAL` 
+
 -----------
 
 # 监视器

--- a/src/main/java/carpettisaddition/CarpetTISAdditionSettings.java
+++ b/src/main/java/carpettisaddition/CarpetTISAdditionSettings.java
@@ -232,4 +232,10 @@ public class CarpetTISAdditionSettings
 			return "You must choose a value from 0 to 1";
 		}
 	}
+
+	@Rule(
+		desc="The mobs in lazy chunks will not despawn",
+		category = {EXPERIMENTAL, FEATURE}
+	)
+	public static boolean keepMobInLazyChunks = false;
 }

--- a/src/main/java/carpettisaddition/CarpetTISAdditionSettings.java
+++ b/src/main/java/carpettisaddition/CarpetTISAdditionSettings.java
@@ -235,7 +235,7 @@ public class CarpetTISAdditionSettings
 
 	@Rule(
 		desc="The mobs in lazy chunks will not despawn",
-		category = {EXPERIMENTAL, FEATURE}
+		category = {TIS, EXPERIMENTAL, FEATURE}
 	)
 	public static boolean keepMobInLazyChunks = false;
 }

--- a/src/main/java/carpettisaddition/mixins/option/MobEntity_keepMobInLazyChunksMixin.java
+++ b/src/main/java/carpettisaddition/mixins/option/MobEntity_keepMobInLazyChunksMixin.java
@@ -1,0 +1,36 @@
+package carpettisaddition.mixins.option;
+
+import carpettisaddition.CarpetTISAdditionSettings;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.ai.control.LookControl;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MobEntity.class)
+public abstract class MobEntity_keepMobInLazyChunksMixin extends LivingEntity {
+    @Shadow
+    public abstract LookControl getLookControl();
+
+    @Shadow
+    public void checkDespawn() {}
+
+    protected MobEntity_keepMobInLazyChunksMixin(EntityType<? extends LivingEntity> entityType_1, World world_1)
+    {
+        super(entityType_1, world_1);
+    }
+
+    @Inject(method = "tickNewAi", at = @At("HEAD"))
+    private void mixin(CallbackInfo ci){
+        if(CarpetTISAdditionSettings.keepMobInLazyChunks){
+            ++super.despawnCounter;
+            this.checkDespawn();
+            --super.despawnCounter;
+        }
+    }
+}

--- a/src/main/java/carpettisaddition/mixins/option/MobEntity_keepMobInLazyChunksMixin.java
+++ b/src/main/java/carpettisaddition/mixins/option/MobEntity_keepMobInLazyChunksMixin.java
@@ -25,12 +25,14 @@ public abstract class MobEntity_keepMobInLazyChunksMixin extends LivingEntity {
         super(entityType_1, world_1);
     }
 
-    @Inject(method = "tickNewAi", at = @At("HEAD"))
+    @Inject(method = "tickNewAi", at = @At(
+        value = "INVOKE_STRING",
+        target = "Lnet/minecraft/util/profiler/Profiler;push(Ljava/lang/String;)V",
+        args = "ldc=sensing"
+    ))
     private void mixin(CallbackInfo ci){
         if(CarpetTISAdditionSettings.keepMobInLazyChunks){
-            ++super.despawnCounter;
             this.checkDespawn();
-            --super.despawnCounter;
         }
     }
 }

--- a/src/main/java/carpettisaddition/mixins/option/ServerWorld_keepMobInLazyChunksMixin.java
+++ b/src/main/java/carpettisaddition/mixins/option/ServerWorld_keepMobInLazyChunksMixin.java
@@ -1,0 +1,22 @@
+package carpettisaddition.mixins.option;
+
+import carpettisaddition.CarpetTISAdditionSettings;
+import net.minecraft.entity.Entity;
+import net.minecraft.server.world.ServerWorld;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+
+@Mixin(ServerWorld.class)
+public abstract class ServerWorld_keepMobInLazyChunksMixin {
+
+    @Redirect(method = "tick", at = @At(
+        value = "INVOKE",
+        target = "Lnet/minecraft/entity/Entity;checkDespawn()V"
+    ))
+    private void dummyCheckDespawn(Entity entity) {
+        if(!CarpetTISAdditionSettings.keepMobInLazyChunks)
+            entity.checkDespawn();
+    }
+}

--- a/src/main/resources/assets/carpettisaddition/lang/zh_cn.json
+++ b/src/main/resources/assets/carpettisaddition/lang/zh_cn.json
@@ -61,6 +61,9 @@
   "rule.commandRaid.name": "袭击追踪器",
   "rule.commandRaid.desc": "启用/raid命令用于追踪袭击信息",
 
+  "rule.keepMobInLazyChunks.name": "保持弱加载区块的怪物",
+  "rule.keepMobInLazyChunks.desc": "弱加载区块的怪物不再会被刷新掉",
+
 
   "logger.ticket.added": "被添加",
   "logger.ticket.removed": "被移除",

--- a/src/main/resources/carpet-tis-addition.mixins.json
+++ b/src/main/resources/carpet-tis-addition.mixins.json
@@ -28,7 +28,9 @@
     "option.PistonBlock_tntDupingFixMixin",
     "option.ServerWorld_blockEventPacketRangeMixin",
     "option.StructureBlockBlockEntity_structureBlockLimitMixin",
-    "option.UpdateStructureBlockC2SPacket_structureBlockLimitMixin"
+    "option.UpdateStructureBlockC2SPacket_structureBlockLimitMixin",
+    "option.MobEntity_keepMobInLazyChunksMixin",
+    "option.ServerWorld_keepMobInLazyChunksMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Mojang 在 19w45a 中由于修复 MC-155289，弱加载区块的怪物也会被 despawn 了，这也导致 1.14.4 及以前的伪和平很多都失效了。

这里添加一个开关，让弱加载区块的怪物 despawn 变得可控，使得原来 1.14.4 及以前的伪和平设计可以继续使用。

该代码已经在 1.15.2 上测试通过，不确定 1.16 及以后的版本能否可用。