### PR TITLE
Migrate Scarpet functions to the new Annotated Scarpet API

### DIFF
--- a/src/main/java/carpettisaddition/CarpetTISAdditionServer.java
+++ b/src/main/java/carpettisaddition/CarpetTISAdditionServer.java
@@ -3,6 +3,7 @@ package carpettisaddition;
 import carpet.CarpetExtension;
 import carpet.CarpetServer;
 import carpet.script.CarpetExpression;
+import carpet.script.annotation.AnnotationParser;
 import carpettisaddition.commands.lifetime.LifeTimeCommand;
 import carpettisaddition.commands.lifetime.LifeTimeTracker;
 import carpettisaddition.commands.raid.RaidCommand;
@@ -53,6 +54,7 @@ public class CarpetTISAdditionServer implements CarpetExtension
     {
         CarpetServer.settingsManager.parseSettingsClass(CarpetTISAdditionSettings.class);
 
+        AnnotationParser.parseFunctionClass(Functions.class);
         MicroTimingEvent.noop();  //to register event properly
     }
 
@@ -111,11 +113,5 @@ public class CarpetTISAdditionServer implements CarpetExtension
     public Map<String, String> canHasTranslations(String lang)
     {
         return TISAdditionTranslations.getTranslationFromResourcePath(lang);
-    }
-
-    @Override
-    public void scarpetApi(CarpetExpression expression)
-    {
-        Functions.apply(expression.getExpr());
     }
 }

--- a/src/main/java/carpettisaddition/script/Functions.java
+++ b/src/main/java/carpettisaddition/script/Functions.java
@@ -2,33 +2,34 @@ package carpettisaddition.script;
 
 import carpet.script.annotation.Locator;
 import carpet.script.annotation.ScarpetFunction;
-import carpet.script.value.BlockValue;
 import carpet.script.value.ListValue;
 import carpet.script.value.Value;
+import carpet.script.value.ValueConversions;
 import carpettisaddition.logging.loggers.microtiming.MicroTimingLoggerManager;
+import net.minecraft.util.math.BlockPos;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class Functions {
     @ScarpetFunction(maxParams = 3)
-    public boolean register_block(@Locator.Block BlockValue block) {
-        return MicroTimingLoggerManager.trackedPositions.add(block.getPos());
+    public boolean register_block(@Locator.Block BlockPos pos) {
+        return MicroTimingLoggerManager.trackedPositions.add(pos);
     }
     
     @ScarpetFunction(maxParams = 3)
-    public boolean unregister_block(@Locator.Block BlockValue block) {
-        return MicroTimingLoggerManager.trackedPositions.remove(block.getPos());
+    public boolean unregister_block(@Locator.Block BlockPos pos) {
+        return MicroTimingLoggerManager.trackedPositions.remove(pos);
     }
     
     @ScarpetFunction
     public ListValue registered_blocks() {
-        List<Value> blockList = MicroTimingLoggerManager.trackedPositions.stream().map(b-> ListValue.fromTriple(b.getX(),b.getY(),b.getZ())).collect(Collectors.toList());
+        List<Value> blockList = MicroTimingLoggerManager.trackedPositions.stream().map(ValueConversions::of).collect(Collectors.toList());
         return new ListValue(blockList);
     }
     
     @ScarpetFunction(maxParams = 3)
-    public boolean is_registered(@Locator.Block BlockValue block) {
-        return MicroTimingLoggerManager.trackedPositions.contains(block.getPos());
+    public boolean is_registered(@Locator.Block BlockPos pos) {
+        return MicroTimingLoggerManager.trackedPositions.contains(pos);
     }
 }

--- a/src/main/java/carpettisaddition/script/Functions.java
+++ b/src/main/java/carpettisaddition/script/Functions.java
@@ -1,50 +1,34 @@
 package carpettisaddition.script;
 
-import carpet.script.CarpetContext;
-import carpet.script.Expression;
-import carpet.script.argument.BlockArgument;
+import carpet.script.annotation.Locator;
+import carpet.script.annotation.ScarpetFunction;
+import carpet.script.value.BlockValue;
 import carpet.script.value.ListValue;
-import carpet.script.value.NumericValue;
 import carpet.script.value.Value;
 import carpettisaddition.logging.loggers.microtiming.MicroTimingLoggerManager;
-import net.minecraft.util.math.BlockPos;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class Functions {
-    public static void apply(Expression expr){
-        expr.addContextFunction("register_block", -1, (c, t, lv)->{
-
-            CarpetContext cc = (CarpetContext)c;
-            BlockArgument blockLocator = BlockArgument.findIn(cc, lv, 0);
-            BlockPos registeredBlock = blockLocator.block.getPos();
-
-            return new NumericValue(MicroTimingLoggerManager.trackedPositions.add(registeredBlock));
-        });
-
-        expr.addContextFunction("unregister_block", -1, (c, t, lv)->{
-
-            CarpetContext cc = (CarpetContext)c;
-            BlockArgument blockLocator = BlockArgument.findIn(cc, lv, 0);
-            BlockPos registeredBlock = blockLocator.block.getPos();
-
-            return new NumericValue(MicroTimingLoggerManager.trackedPositions.remove(registeredBlock));
-        });
-
-        expr.addContextFunction("registered_blocks", 0, (c, t, lv)->{
-
-            List<Value> blockList = MicroTimingLoggerManager.trackedPositions.stream().map(b-> ListValue.fromTriple(b.getX(),b.getY(),b.getZ())).collect(Collectors.toList());
-            return new ListValue(blockList);
-        });
-
-        expr.addContextFunction("is_registered", -1, (c, t, lv)->{
-
-            CarpetContext cc = (CarpetContext)c;
-            BlockArgument blockLocator = BlockArgument.findIn(cc, lv, 0);
-            BlockPos registeredBlock = blockLocator.block.getPos();
-
-            return new NumericValue(MicroTimingLoggerManager.trackedPositions.contains(registeredBlock));
-        });
+    @ScarpetFunction(maxParams = 3)
+    public boolean register_block(@Locator.Block BlockValue block) {
+        return MicroTimingLoggerManager.trackedPositions.add(block.getPos());
+    }
+    
+    @ScarpetFunction(maxParams = 3)
+    public boolean unregister_block(@Locator.Block BlockValue block) {
+        return MicroTimingLoggerManager.trackedPositions.remove(block.getPos());
+    }
+    
+    @ScarpetFunction
+    public ListValue registered_blocks() {
+        List<Value> blockList = MicroTimingLoggerManager.trackedPositions.stream().map(b-> ListValue.fromTriple(b.getX(),b.getY(),b.getZ())).collect(Collectors.toList());
+        return new ListValue(blockList);
+    }
+    
+    @ScarpetFunction(maxParams = 3)
+    public boolean is_registered(@Locator.Block BlockValue block) {
+        return MicroTimingLoggerManager.trackedPositions.contains(block.getPos());
     }
 }


### PR DESCRIPTION
The Annotated Scarpet PR for Carpet (gnembon/fabric-carpet#772) was recently merged, meaning that it'll be available in the next release (old should still be there). Advantages of it include faster and cleaner scarpet function coding (since you don't have to place conversions everywhere basically), the contract of being a stable API that won't change once it's released, full documentation of how to use it in javadocs, and that you can reuse the methods and call them from your java code if you need them, by changing them to static.

This PR adapts all Scarpet functions in Carpet TIS Addition to use the new API, trying to keep the exact same behaviour (haven't checked, please do).

Events aren't touched since they still don't have an actual API.

Still a draft since Annotated Scarpet hasn't got yet into maven. This PR also uses features from gnembon/fabric-carpet#884.