### PR TITLE
lifetime: add thrown by entity spawn reason

### DIFF
--- a/src/main/java/carpettisaddition/commands/lifetime/spawning/MobThrowSpawningReason.java
+++ b/src/main/java/carpettisaddition/commands/lifetime/spawning/MobThrowSpawningReason.java
@@ -1,0 +1,38 @@
+package carpettisaddition.commands.lifetime.spawning;
+
+import carpet.utils.Messenger;
+import net.minecraft.entity.EntityType;
+import net.minecraft.text.BaseText;
+
+import java.util.Objects;
+
+// for item or other entity intentionally throw by entity
+public class MobThrowSpawningReason extends SpawningReason {
+	private final EntityType<?> providerType;
+
+	public MobThrowSpawningReason(EntityType<?> providerType) {
+		this.providerType = providerType;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		MobThrowSpawningReason that = (MobThrowSpawningReason) o;
+		return Objects.equals(providerType, that.providerType);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(providerType);
+	}
+
+	@Override
+	public BaseText toText() {
+		return Messenger.c(
+				"w " + this.tr("mob_throw.pre", "Thrown by "),
+				this.providerType.getName(),
+				"w " + this.tr("mob_throw.post", "")
+		);
+	}
+}

--- a/src/main/java/carpettisaddition/mixins/command/lifetime/spawning/LookTargetUtilMixin.java
+++ b/src/main/java/carpettisaddition/mixins/command/lifetime/spawning/LookTargetUtilMixin.java
@@ -1,0 +1,29 @@
+package carpettisaddition.mixins.command.lifetime.spawning;
+
+import carpettisaddition.commands.lifetime.interfaces.IEntity;
+import carpettisaddition.commands.lifetime.spawning.MobThrowSpawningReason;
+import net.minecraft.entity.ItemEntity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.ai.brain.task.LookTargetUtil;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+
+@Mixin(LookTargetUtil.class)
+public class LookTargetUtilMixin {
+    @Inject(
+            method = "give",
+            locals = LocalCapture.CAPTURE_FAILHARD,
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/World;spawnEntity(Lnet/minecraft/entity/Entity;)Z"
+            )
+    )
+    private static void onThrowItemEntityLifeTimeTracker(LivingEntity entity, ItemStack stack, LivingEntity target, CallbackInfo ci, double ignored, ItemEntity itemEntity) {
+        ((IEntity) itemEntity).recordSpawning(new MobThrowSpawningReason(entity.getType()));
+    }
+}

--- a/src/main/java/carpettisaddition/mixins/command/lifetime/spawning/PlayerEntityMixin.java
+++ b/src/main/java/carpettisaddition/mixins/command/lifetime/spawning/PlayerEntityMixin.java
@@ -1,7 +1,7 @@
 package carpettisaddition.mixins.command.lifetime.spawning;
 
 import carpettisaddition.commands.lifetime.interfaces.IEntity;
-import carpettisaddition.commands.lifetime.spawning.MobDropSpawningReason;
+import carpettisaddition.commands.lifetime.spawning.MobThrowSpawningReason;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.LivingEntity;
@@ -26,7 +26,7 @@ public abstract class PlayerEntityMixin extends LivingEntity
 		ItemEntity itemEntity = cir.getReturnValue();
 		if (itemEntity != null)
 		{
-			((IEntity)itemEntity).recordSpawning(new MobDropSpawningReason(this.getType()));
+			((IEntity)itemEntity).recordSpawning(new MobThrowSpawningReason(this.getType()));
 		}
 	}
 }

--- a/src/main/resources/assets/carpettisaddition/lang/zh_cn.json
+++ b/src/main/resources/assets/carpettisaddition/lang/zh_cn.json
@@ -478,6 +478,8 @@
   "tracker.lifetime.spawn_reason.spawner": "刷怪笼",
   "tracker.lifetime.spawn_reason.mob_drop.pre": "由",
   "tracker.lifetime.spawn_reason.mob_drop.post": "掉落",
+  "tracker.lifetime.spawn_reason.mob_throw.pre": "由",
+  "tracker.lifetime.spawn_reason.mob_throw.post": "扔出",
   "tracker.lifetime.spawn_reason.trans_dimension": "跨维度",
   "tracker.lifetime.spawn_reason.trans_dimension.from": "来自",
   "tracker.lifetime.removal_reason.despawn.randomly": "随机消失",

--- a/src/main/resources/assets/carpettisaddition/lang/zh_tw.json
+++ b/src/main/resources/assets/carpettisaddition/lang/zh_tw.json
@@ -368,6 +368,8 @@
   "tracker.lifetime.spawn_reason.zombie_reinforce": "殭屍增援",
   "tracker.lifetime.spawn_reason.mob_drop.pre": "由",
   "tracker.lifetime.spawn_reason.mob_drop.post": "掉落",
+  "tracker.lifetime.spawn_reason.mob_throw.pre": "由",
+  "tracker.lifetime.spawn_reason.mob_throw.post": "扔出",
   "tracker.lifetime.spawn_reason.trans_dimension": "跨維度",
   "tracker.lifetime.spawn_reason.trans_dimension.from": "來自",
   "tracker.lifetime.removal_reason.despawn.randomly": "隨機消失",

--- a/src/main/resources/carpet-tis-addition.mixins.json
+++ b/src/main/resources/carpet-tis-addition.mixins.json
@@ -57,6 +57,7 @@
     "command.lifetime.spawning.EntityMixin",
     "command.lifetime.spawning.EntityTypeMixin",
     "command.lifetime.spawning.LivingEntityMixin",
+    "command.lifetime.spawning.LookTargetUtilMixin",
     "command.lifetime.spawning.MobSpawnerLogicMixin",
     "command.lifetime.spawning.NetherPortalBlockMixin",
     "command.lifetime.spawning.PlayerEntityMixin",


### PR DESCRIPTION
Lifetime tracker can't track item entities thrown by villagers and piglins (in 1.16+). This PR adds a new spawn reason to track these entities.

For higher Minecraft version, the `LookTargetUtil#give` have a different method signature (type of target argument changed from `LivingEntity` to `Vec3d`).

Sorry for my not fully understanding the development guidelines. :(