### PR TITLE
Fixed zh_cn translation for ticket logger

### DIFF
--- a/src/main/resources/assets/carpettisaddition/lang/zh_cn.yml
+++ b/src/main/resources/assets/carpettisaddition/lang/zh_cn.yml
@@ -16,9 +16,9 @@ carpettisaddition:
     ticket:
       added: 被添加
       removed: 被移除
-      time_detail: "世界: %s\n游戏刻: %d"
+      time_detail: "世界: %1$s\n游戏刻: %2$s"
       message: 加载票 %1$s 于 %3$s %2$s
-      ticket_detail: "等级 = %d\n持续时间 = %s\n强加载区块: %s\n弱加载区块: %s\n边界区块: %s"
+      ticket_detail: "等级 = %1$s\n持续时间 = %2$s\n强加载区块: %3$s\n弱加载区块: %4$s\n边界区块: %5$s"
       permanent: 永久
     entity:
       created: '%1$s被创建了'


### PR DESCRIPTION
Without this patch:

<img width="221" alt="image" src="https://user-images.githubusercontent.com/57795957/162615336-f228d594-bf4f-47a7-ae4c-cd320ff66eb4.png">
<img width="387" alt="image" src="https://user-images.githubusercontent.com/57795957/162615341-efb4bfbb-a0bf-482d-87cf-d252d8429a40.png">

With this patch:

<img width="329" alt="image" src="https://user-images.githubusercontent.com/57795957/162615383-64b81fcb-befa-4555-8aa5-0374ede1bb73.png">
<img width="373" alt="image" src="https://user-images.githubusercontent.com/57795957/162615482-68059585-2a9a-4482-b846-91a4da6c49ed.png">

