### PR TITLE
enable SimpleNeighborUpdater

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -746,6 +746,19 @@ In sand dupers sand will only get teleported to the other dimension
 - Categories: `TIS`, `BUGFIX`
 
 
+## simpleNeighborUpdaterEnabled
+
+Enable legacy NC updater
+
+In 1.19, using new NC updater means that you cannot use old update suppressor. (PS: I hope new vanilla update suppressor can be developed in future)
+
+Enable legacy NC updater can make this powerful technology useful again.
+
+- Type: `boolean`
+- Default value: `false`
+- Suggested options: `false`, `true`
+- Categories: `TIS`
+
 ## snowMeltMinLightLevel
 
 The minimum light level allowed for snow to melt

--- a/docs/rules_cn.md
+++ b/docs/rules_cn.md
@@ -746,6 +746,20 @@
 - 分类: `TIS`, `BUGFIX`
 
 
+## 启用旧版NC更新器（simpleNeighborUpdaterEnabled）
+
+启用旧版NC更新器
+
+在1.19中，使用新版NC更新器意味着不能使用传统的更新抑制器（衷心希望新的原版更新抑制器能研发出来）
+
+启用旧版NC更新器将会让这项强大的技术得以重新使用
+
+- 类型: `boolean`
+- 默认值: `false`
+- 参考选项: `false`, `true`
+- 分类: `TIS`
+
+
 ## 融雪最小亮度 (snowMeltMinLightLevel)
 
 雪片融化所需的最小亮度等级

--- a/src/main/java/carpettisaddition/CarpetTISAdditionSettings.java
+++ b/src/main/java/carpettisaddition/CarpetTISAdditionSettings.java
@@ -839,6 +839,15 @@ public class CarpetTISAdditionSettings
 	}
 
 	@Rule(
+			desc = "Enable old neighbor updater before 1.19",
+			extra = {
+					"You can use update suppression if you enable that"
+			},
+			category = {TIS}
+	)
+	public static boolean simpleNeighborUpdaterEnabled = false;
+
+	@Rule(
 			desc = "Enable visualize projectile logger",
 			extra = {
 					"Try /log projectiles visualize"

--- a/src/main/java/carpettisaddition/helpers/rule/simpleNeighborUpdater/MutableNeighborUpdater.java
+++ b/src/main/java/carpettisaddition/helpers/rule/simpleNeighborUpdater/MutableNeighborUpdater.java
@@ -1,0 +1,58 @@
+package carpettisaddition.helpers.rule.simpleNeighborUpdater;
+
+import carpettisaddition.CarpetTISAdditionSettings;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.World;
+import net.minecraft.world.block.ChainRestrictedNeighborUpdater;
+import net.minecraft.world.block.NeighborUpdater;
+import net.minecraft.world.block.SimpleNeighborUpdater;
+import org.jetbrains.annotations.Nullable;
+
+public class MutableNeighborUpdater implements NeighborUpdater {
+    private final SimpleNeighborUpdater oldNeighborUpdater;
+    private final ChainRestrictedNeighborUpdater newNeighborUpdater;
+
+    public MutableNeighborUpdater(World world, ChainRestrictedNeighborUpdater updater) {
+        this.oldNeighborUpdater = new SimpleNeighborUpdater(world);
+        this.newNeighborUpdater = updater;
+    }
+
+    @Override
+    public void replaceWithStateForNeighborUpdate(Direction direction, BlockState neighborState, BlockPos pos, BlockPos neighborPos, int flags, int maxUpdateDepth) {
+        if (CarpetTISAdditionSettings.simpleNeighborUpdaterEnabled) {
+            oldNeighborUpdater.replaceWithStateForNeighborUpdate(direction, neighborState, pos, neighborPos, flags, maxUpdateDepth);
+        } else {
+            newNeighborUpdater.replaceWithStateForNeighborUpdate(direction, neighborState, pos, neighborPos, flags, maxUpdateDepth);
+        }
+    }
+
+    @Override
+    public void updateNeighbor(BlockPos pos, Block sourceBlock, BlockPos sourcePos) {
+        if (CarpetTISAdditionSettings.simpleNeighborUpdaterEnabled) {
+            oldNeighborUpdater.updateNeighbor(pos, sourceBlock, sourcePos);
+        } else {
+            newNeighborUpdater.updateNeighbor(pos, sourceBlock, sourcePos);
+        }
+    }
+
+    @Override
+    public void updateNeighbor(BlockState state, BlockPos pos, Block sourceBlock, BlockPos sourcePos, boolean notify) {
+        if (CarpetTISAdditionSettings.simpleNeighborUpdaterEnabled) {
+            oldNeighborUpdater.updateNeighbor(state, pos, sourceBlock, sourcePos, notify);
+        } else {
+            newNeighborUpdater.updateNeighbor(state, pos, sourceBlock, sourcePos, notify);
+        }
+    }
+
+    @Override
+    public void updateNeighbors(BlockPos pos, Block sourceBlock, @Nullable Direction except) {
+        if (CarpetTISAdditionSettings.simpleNeighborUpdaterEnabled) {
+            oldNeighborUpdater.updateNeighbors(pos, sourceBlock, except);
+        } else {
+            NeighborUpdater.super.updateNeighbors(pos, sourceBlock, except);
+        }
+    }
+}

--- a/src/main/java/carpettisaddition/mixins/rule/simpleNeighborUpdaterEnabled/WorldMixin.java
+++ b/src/main/java/carpettisaddition/mixins/rule/simpleNeighborUpdaterEnabled/WorldMixin.java
@@ -1,0 +1,33 @@
+package carpettisaddition.mixins.rule.simpleNeighborUpdaterEnabled;
+
+import carpettisaddition.helpers.rule.simpleNeighborUpdater.MutableNeighborUpdater;
+import net.minecraft.world.World;
+import net.minecraft.world.block.ChainRestrictedNeighborUpdater;
+import net.minecraft.world.block.NeighborUpdater;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(World.class)
+public class WorldMixin {
+    @Mutable
+    @Final
+    @Shadow
+    protected NeighborUpdater neighborUpdater;
+
+    @Redirect(
+            method = "<init>",
+            at = @At(
+                    value = "FIELD",
+                    target = "Lnet/minecraft/world/World;neighborUpdater:Lnet/minecraft/world/block/NeighborUpdater;",
+                    opcode = Opcodes.PUTFIELD
+            )
+    )
+    private void mixinWorld(World world, NeighborUpdater updater) {
+        this.neighborUpdater = new MutableNeighborUpdater(world, (ChainRestrictedNeighborUpdater) updater);
+    }
+}

--- a/src/main/resources/carpet-tis-addition.mixins.json
+++ b/src/main/resources/carpet-tis-addition.mixins.json
@@ -261,6 +261,7 @@
     "rule.renewableElytra.PhantomEntityMixin",
     "rule.repeaterHalfDelay.AbstractRedstoneGateBlockMixin",
     "rule.sandDupingFix.FallingBlockEntityMixin",
+    "rule.simpleNeighborUpdaterEnabled.WorldMixin",
     "rule.snowMeltMinLightLevel.SnowBlockMixin",
     "rule.structureBlockDoNotPreserveFluid.StructureBlockBlockEntityMixin",
     "rule.structureBlockDoNotPreserveFluid.StructurePlacementDataAccessor",


### PR DESCRIPTION
Enable `SimpleNeighborUpdater` to use legacy NC updater, which means you can suppress update, item shadow, and anything based on update suppression in 1.19 now.

Here  is a screenshot when I test these codes. (Sorry I forgot `F3` to display the version, but you can check version of carpet and Carpet-TIS-Addition to confirm that game version)

![2022-06-08_17 17 50](https://user-images.githubusercontent.com/38467722/172587361-1b25cdf8-94fe-4460-80ac-8fa50fecf18b.png)
