### PR TITLE
修复版本信息中的version没有被翻译

### DIFF
--- a/src/main/java/carpettisaddition/mixins/carpet/hooks/SettingsManagerMixin.java
+++ b/src/main/java/carpettisaddition/mixins/carpet/hooks/SettingsManagerMixin.java
@@ -75,7 +75,11 @@ public class SettingsManagerMixin
 				source,
 				Messenger.c(
 						String.format("g %s ", MOD_NAME),
+						//#if MC >= 11901
+						//$$ String.format("g %s: ", Translations.tr("carpet.settings.command.version",  "version")),
+						//#else
 						String.format("g %s: ", Translations.tr("ui.version",  "version")),
+						//#endif
 						String.format("g %s", CarpetTISAdditionMod.getVersion())
 				)
 		);

--- a/src/main/java/carpettisaddition/mixins/carpet/hooks/SettingsManagerMixin.java
+++ b/src/main/java/carpettisaddition/mixins/carpet/hooks/SettingsManagerMixin.java
@@ -74,8 +74,12 @@ public class SettingsManagerMixin
 		Messenger.tell(
 				source,
 				Messenger.c(
-						String.format("g %s ", MOD_NAME),
+						String.format("g %s ", MOD_NAME), 
+					        //#if MC >= 11901
+					        //$$ String.format("g %s: ", Translations.tr("carpet.settings.command.version",  "version")),
+					        //#else
 						String.format("g %s: ", Translations.tr("ui.version",  "version")),
+					        //#endif
 						String.format("g %s", CarpetTISAdditionMod.getVersion())
 				)
 		);


### PR DESCRIPTION
https://github.com/TISUnion/Carpet-TIS-Addition/issues/142

preprocess判断MC版本大于等于1.19.1，就使用键`carpet.settings.command.version`

否则还是使用`ui.version`