### PR TITLE
可使用shulkerBoxCCEReintroduced在1.20.2以下版本关闭潜影盒更新抑制

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@
 	conditionalmixin_version=0.6.2
 
 	# https://github.com/LlamaLad7/MixinExtras
-	mixinextras_version=0.3.5
+	mixinextras_version=0.4.0-beta.1
 
 	# https://mvnrepository.com/artifact/junit/junit
 	junit_version=4.13.2

--- a/src/main/java/carpettisaddition/CarpetTISAdditionSettings.java
+++ b/src/main/java/carpettisaddition/CarpetTISAdditionSettings.java
@@ -556,9 +556,11 @@ public class CarpetTISAdditionSettings
 	@Rule(categories = {TIS, BUGFIX})
 	public static boolean sandDupingFix = false;
 
+	@Rule(categories = {TIS, PORTING})
 	//#if MC >= 12002
-	//$$ @Rule(categories = {TIS, PORTING})
 	//$$ public static boolean shulkerBoxCCEReintroduced = false;
+	//#else
+	public static boolean shulkerBoxCCEReintroduced = true;
 	//#endif
 
 	//#if MC < 11700

--- a/src/main/java/carpettisaddition/mixins/rule/shulkerBoxCCEReintroduced/ShulkerBoxBlockMixin.java
+++ b/src/main/java/carpettisaddition/mixins/rule/shulkerBoxCCEReintroduced/ShulkerBoxBlockMixin.java
@@ -20,11 +20,36 @@
 
 package carpettisaddition.mixins.rule.shulkerBoxCCEReintroduced;
 
-import carpettisaddition.utils.compat.DummyClass;
+import carpettisaddition.CarpetTISAdditionSettings;
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.ShulkerBoxBlock;
+import net.minecraft.container.Container;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 
-@Mixin(DummyClass.class)
+@Mixin(ShulkerBoxBlock.class)
 public abstract class ShulkerBoxBlockMixin
 {
-	// impl in mc1.20.2
+    @WrapMethod(method = "getComparatorOutput")
+	private int shulkerBoxCCEReintroduced_castIt(BlockState state, World world, BlockPos pos, Operation<Integer> original)
+    {
+        try
+        {
+           return original.call(state, world, pos);
+        }
+        catch (ClassCastException classCastException)
+        {
+            if (CarpetTISAdditionSettings.shulkerBoxCCEReintroduced)
+            {
+                throw classCastException;
+            }
+            else
+            {
+                return Container.calculateComparatorOutput(world.getBlockEntity(pos));
+            }
+        }
+    }
 }


### PR DESCRIPTION
**注意: 需要使用测试版的mixinextras, 因此我它设置成了draft pr**


这是mixin的目标方法
```
    public int getComparatorOutput(BlockState state, World world, BlockPos pos) {
        return Container.calculateComparatorOutput((Inventory)world.getBlockEntity(pos));
    }
```

不使用新注解`@WrapMethod`([WrapMethod](https://github.com/LlamaLad7/MixinExtras/wiki/WrapMethod))好像并没有什么好的办法来解决, 其它注解会因为需要在前面创建变量来储存这个返回值或者需要将这个返回值作为参数传入从而导致发生CCE

有个例外是`@Inject`从头部注入, 但是这么做会"忽略"把注入点设置为`RETURN`的mixin, 从而引起兼容问题. 其它注入点会引起上述的问题

`@Overwrite`碾平一切阻碍虽然可以根治问题, 不过使用它并不是一个好主意

## 其它
1. 我把它在1.20.2以下的默认值设置成了`true`, 设置为`false`即可修复潜影盒更新抑制

2. 我想是不是在1.20.2以下把这个选项移动到`BUGFIX`中?