### PR TITLE
docs(misc): 修复错误的中文链接识别

### DIFF
--- a/website/docs/misc.md
+++ b/website/docs/misc.md
@@ -99,5 +99,5 @@ Rule [microTiming](rules.md#microtiming) is required to be true for dispatching 
 ## Carpet Misc Tweaks
 
 - Cancelled player action pack (triggered by `/player` command) ticking during `/tick freeze`
-- Fixed carpet fake player not responding to knockback from player melee attack (https://github.com/gnembon/fabric-carpet/issues/745), which is fixed in fabric-carpet v1.4.33
+- Fixed carpet fake player not responding to knockback from player melee attack ([gnembon/fabric-carpet#745](https://github.com/gnembon/fabric-carpet/issues/745)), which is fixed in fabric-carpet v1.4.33
 - Fixed scarpet shape crash when sending shapes to non-carpet clients using alternative particles, affecting MC version 1.20.5 ~ 1.21.4. It's fixed in fabric-carpet v1.4.169 at [da5b937](https://github.com/gnembon/fabric-carpet/commit/da5b937e78c949ecea743cf607fb3d31249b48e6)

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/misc.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/misc.md
@@ -100,5 +100,5 @@ sidebar_position: 4
 ## Carpet 相关其他修改
 
 - 取消玩家动作包（由 `/player` 指令触发的 PlayerActionPack）在 `/tick freeze` 时的更新
-- 修复地毯假人不响应玩家近战攻击的击退的 bug (https://github.com/gnembon/fabric-carpet/issues/745)。此问题已在 fabric-carpet v1.4.33 中得以修复
+- 修复地毯假人不响应玩家近战攻击的击退的 bug ( https://github.com/gnembon/fabric-carpet/issues/745 )。此问题已在 fabric-carpet v1.4.33 中得以修复
 - 修复了在使用粒子效果这一替代方案来将 scarpet shape 发送给非 carpet 客户端时，服务端发生的 `unknown_particle` 崩溃，影响 MC 1.20.5 ~ 1.21.4。此问题已在 fabric-carpet v1.4.169 中的提交 [da5b937](https://github.com/gnembon/fabric-carpet/commit/da5b937e78c949ecea743cf607fb3d31249b48e6) 中修复

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/misc.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/misc.md
@@ -100,5 +100,5 @@ sidebar_position: 4
 ## Carpet 相关其他修改
 
 - 取消玩家动作包（由 `/player` 指令触发的 PlayerActionPack）在 `/tick freeze` 时的更新
-- 修复地毯假人不响应玩家近战攻击的击退的 bug ( https://github.com/gnembon/fabric-carpet/issues/745 )。此问题已在 fabric-carpet v1.4.33 中得以修复
+- 修复地毯假人不响应玩家近战攻击的击退的 bug ([gnembon/fabric-carpet#745](https://github.com/gnembon/fabric-carpet/issues/745))。此问题已在 fabric-carpet v1.4.33 中得以修复
 - 修复了在使用粒子效果这一替代方案来将 scarpet shape 发送给非 carpet 客户端时，服务端发生的 `unknown_particle` 崩溃，影响 MC 1.20.5 ~ 1.21.4。此问题已在 fabric-carpet v1.4.169 中的提交 [da5b937](https://github.com/gnembon/fabric-carpet/commit/da5b937e78c949ecea743cf607fb3d31249b48e6) 中修复


### PR DESCRIPTION
Docusaurus的中文的链接识别有问题
<img width="601" height="133" alt="image" src="https://github.com/user-attachments/assets/d57017ae-c2b3-43ee-b398-f984fadf6b7c" />
会导致issue无法正常跳转
在链接两侧添加空格以修复